### PR TITLE
[SPA-017] [Angular] [Play Framework] [認証機能] 登録済みe-mailバリデーション

### DIFF
--- a/app/controllers/api/authenticate/Signup.scala
+++ b/app/controllers/api/authenticate/Signup.scala
@@ -60,18 +60,4 @@ class UserSignupController @Inject()(
         case Right(success) => success
       }
   }
-
-  def isAuthenticate() = Action {implicit request =>
-    val cookies = request.cookies.get("My-Xsrf-Cookie")
-    val jsWritesAuth = JsValueWritesIsAuth(
-      isAuth = cookies match {
-        case Some(_) => true
-        case None    => false
-      }
-    )
-    cookies match {
-      case Some(_) => Ok(Json.toJson(jsWritesAuth))
-      case None    => BadRequest
-    }
-  }
 }

--- a/app/controllers/api/service/Validation.scala
+++ b/app/controllers/api/service/Validation.scala
@@ -3,16 +3,22 @@ package controllers.api.service
 import javax.inject.Inject
 import scala.concurrent.{Future, ExecutionContext}
 
-import json.reads.JsValueReadsUser
-import json.writes.JsValueWritesIsAuth
+import json.reads.JsValueReadsEmail
+import json.writes.{JsValueWritesIsAuth, JsValueWritesEmailValid}
+
+import cats.data.EitherT
+import cats.implicits._
 
 import play.api.mvc._
 import play.api.libs.json._
 import play.api.i18n.I18nSupport
 import play.api.libs.json.JsPath.json
 
+import lib.persistence.UserRepository
+
 class ValidationController @Inject()(
-  cc: MessagesControllerComponents
+  uerRepo: UserRepository,
+  cc:      MessagesControllerComponents
 )(implicit ec: ExecutionContext)
   extends MessagesAbstractController(cc)
   with    I18nSupport {
@@ -31,7 +37,15 @@ class ValidationController @Inject()(
     }
   }
 
-  def emailValidation() = Action(parse.json) async {implicit request =>
-    ???
+  def isEmailRegistered() = Action(parse.json) async {implicit request =>
+    val jsonEmail = request.body.validate[JsValueReadsEmail].get
+    for {
+      email <- uerRepo.filterByMail(jsonEmail.email)
+    } yield {
+      email match {
+        case Some(_) => Ok(Json.toJson(JsValueWritesEmailValid(isRegistered = true)))
+        case None    => Ok(Json.toJson(JsValueWritesEmailValid(isRegistered = false)))
+      }
+    }
   }
 }

--- a/app/controllers/api/service/Validation.scala
+++ b/app/controllers/api/service/Validation.scala
@@ -1,0 +1,37 @@
+package controllers.api.service
+
+import javax.inject.Inject
+import scala.concurrent.{Future, ExecutionContext}
+
+import json.reads.JsValueReadsUser
+import json.writes.JsValueWritesIsAuth
+
+import play.api.mvc._
+import play.api.libs.json._
+import play.api.i18n.I18nSupport
+import play.api.libs.json.JsPath.json
+
+class ValidationController @Inject()(
+  cc: MessagesControllerComponents
+)(implicit ec: ExecutionContext)
+  extends MessagesAbstractController(cc)
+  with    I18nSupport {
+
+  def isAuthenticate() = Action {implicit request =>
+    val cookies = request.cookies.get("My-Xsrf-Cookie")
+    val jsWritesAuth = JsValueWritesIsAuth(
+      isAuth = cookies match {
+        case Some(_) => true
+        case None    => false
+      }
+    )
+    cookies match {
+      case Some(_) => Ok(Json.toJson(jsWritesAuth))
+      case None    => BadRequest
+    }
+  }
+
+  def emailValidation() = Action(parse.json) async {implicit request =>
+    ???
+  }
+}

--- a/app/json/reads/User.scala
+++ b/app/json/reads/User.scala
@@ -11,3 +11,11 @@ case class JsValueReadsUser(
 object  JsValueReadsUser {
   implicit val userReads = Json.reads[JsValueReadsUser]
 }
+
+case class JsValueReadsEmail(
+  email: String
+)
+
+object  JsValueReadsEmail {
+  implicit val emailReads = Json.reads[JsValueReadsEmail]
+}

--- a/app/json/writes/User.scala
+++ b/app/json/writes/User.scala
@@ -7,6 +7,14 @@ case class JsValueWritesUser(
   fullname: String,
 )
 
-object  JsValueWritesUser {
+object JsValueWritesUser {
   implicit val userWrites = Json.writes[JsValueWritesUser]
+}
+
+case class JsValueWritesEmailValid(
+  isRegistered: Boolean,
+)
+
+object JsValueWritesEmailValid {
+  implicit val emaliValidWrites = Json.writes[JsValueWritesEmailValid]
 }

--- a/app/lib/persistence/user/User.scala
+++ b/app/lib/persistence/user/User.scala
@@ -35,6 +35,12 @@ class UserRepository @Inject()
       .result.headOption
     }
 
+  def getEmail(email: String): Future[String] =
+    db.run {
+      user.filter(_.email === email)
+        .result.head.map(_.email)
+    }
+
   /**
    *
    * ※要修正

--- a/conf/sub.api.routes
+++ b/conf/sub.api.routes
@@ -9,4 +9,5 @@ POST   /auth/signup           controllers.api.authenticate.UserSignupController.
 DELETE /auth/logout           controllers.api.authenticate.UserLogoutController.logout
 
 # validation API
-GET    /auth/isAuthenticate   controllers.api.service.ValidationController.isAuthenticate
+GET    /auth/isAuthenticate      controllers.api.service.ValidationController.isAuthenticate
+POST   /auth/isEmailRegistered   controllers.api.service.ValidationController.isEmailRegistered

--- a/conf/sub.api.routes
+++ b/conf/sub.api.routes
@@ -3,7 +3,10 @@
 # https://www.playframework.com/documentation/latest/ScalaRouting
 # ~~~~
 
+# authenticate API
 POST   /auth/login            controllers.api.authenticate.UserLoginController.login
 POST   /auth/signup           controllers.api.authenticate.UserSignupController.signup
 DELETE /auth/logout           controllers.api.authenticate.UserLogoutController.logout
-GET    /auth/isAuthenticate   controllers.api.authenticate.UserSignupController.isAuthenticate
+
+# validation API
+GET    /auth/isAuthenticate   controllers.api.service.ValidationController.isAuthenticate

--- a/ui/src/app/auth/email/email.component.ts
+++ b/ui/src/app/auth/email/email.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit }    from '@angular/core';
+import { Component, OnInit, Input }    from '@angular/core';
 
 import { ValidationMessages }   from '../validation-messages'
 import { ValidationService }    from '../../service/validation.service';
@@ -10,13 +10,18 @@ import { ValidationService }    from '../../service/validation.service';
 })
 export class EmailComponent implements OnInit {
 
+  @Input() isSignup: boolean;
+
   constructor(
     public validationMessages: ValidationMessages,
     public validationService:  ValidationService
   ) {}
 
-  ngOnInit(): void {
-  }
+  ngOnInit(): void {}
 
-  email = this.validationService.validateEmail()
+  /**
+   * 共通化処理をした場合にバリデーションの条件分岐が上手くいかなかったため、
+   * 一旦保留
+   */
+  email = this.validationService.emailRegisteredNone();
 }

--- a/ui/src/app/auth/login/login.component.html
+++ b/ui/src/app/auth/login/login.component.html
@@ -1,6 +1,14 @@
 <form [formGroup]="loginForm" (ngSubmit)="onSubmit()" class="form-field">
 
-  <app-email></app-email>
+  <div class="form-field__mail">
+    <label for="email">メールアドレス</label>
+    <input id="email" name="email" type="email" [formControl]="email" />
+    <ng-container *ngFor="let validation of validationMessages.email">
+      <span *ngIf="email.hasError(validation.type) && (email.dirty || email.touched)">
+        {{validation.message}}
+      </span>
+    </ng-container>
+  </div>
 
   <app-password></app-password>
 

--- a/ui/src/app/auth/login/login.component.ts
+++ b/ui/src/app/auth/login/login.component.ts
@@ -1,7 +1,7 @@
 // ---- [ @angular ] ------------------------------------------------
 import { Component, OnInit }  from '@angular/core';
 import { Router }             from '@angular/router';
-import { FormGroup }          from '@angular/forms';
+import { FormGroup, FormControl, Validators }          from '@angular/forms';
 
 // ---- [ Interface ] -----------------------------------------------
 import { User }                 from '../../interface/user';
@@ -27,8 +27,16 @@ export class LoginComponent implements OnInit {
     public  validationMessages: ValidationMessages
   ) {}
 
+  email = new FormControl('',
+    [
+      Validators.required,
+      Validators.email,
+    ],
+    this.validationService.emailRegisteredNone()
+  );
+
   loginForm = new FormGroup({
-    email:    this.validationService.validateEmail(),
+    email:    this.email,
     password: this.validationService.validatePassword()
   });
 

--- a/ui/src/app/auth/signup/signup.component.html
+++ b/ui/src/app/auth/signup/signup.component.html
@@ -16,7 +16,15 @@
     </span>
   </div>
 
-  <app-email></app-email>
+  <div class="form-field__mail">
+    <label for="email">メールアドレス</label>
+    <input id="email" name="email" type="email" [formControl]="email" />
+    <ng-container *ngFor="let validation of validationMessages.email">
+      <span *ngIf="email.hasError(validation.type) && (email.dirty || email.touched)">
+        {{validation.message}}
+      </span>
+    </ng-container>
+  </div>
 
   <app-password></app-password>
 

--- a/ui/src/app/auth/signup/signup.component.ts
+++ b/ui/src/app/auth/signup/signup.component.ts
@@ -25,8 +25,7 @@ export class SignupComponent implements OnInit {
     public  validationMessages: ValidationMessages
   ) {}
 
-  ngOnInit(): void {
-  }
+  ngOnInit(): void {}
 
   firstName = new FormControl('', [
     Validators.required
@@ -36,10 +35,18 @@ export class SignupComponent implements OnInit {
     Validators.required
   ]);
 
+  email = new FormControl('',
+    [
+      Validators.required,
+      Validators.email,
+    ],
+    this.validationService.emailRegisteredSome()
+  );
+
   signupForm = new FormGroup({
     firstName: this.firstName,
     lastName:  this.lastName,
-    email:     this.validationService.validateEmail(),
+    email:     this.email,
     password:  this.validationService.validatePassword()
   });
 

--- a/ui/src/app/auth/validation-messages.ts
+++ b/ui/src/app/auth/validation-messages.ts
@@ -6,9 +6,12 @@ import {Injectable} from '@angular/core';
 
 export class ValidationMessages {
   email = [
-    { type: 'required', message: 'メールアドレスは必須項目です' },
-    { type: 'email',    message: 'メールアドレスは正しい形式で入力してください' }
+    { type: 'required',   message: 'メールアドレスは必須項目です' },
+    { type: 'email',      message: 'メールアドレスは正しい形式で入力してください' },
+    { type: 'registered', message: 'このメールアドレスはすでに使われています'},
+    { type: 'none',       message: 'このメールアドレスは登録されていません'}
   ];
+
   password = [
     { type: 'required',  message: 'パスワードは必須項目です' },
     { type: 'minlength', message: 'パスワードは8文字以上で入力してください' },

--- a/ui/src/app/interface/user.ts
+++ b/ui/src/app/interface/user.ts
@@ -10,6 +10,10 @@ export interface Signup {
   password:  string;
 }
 
+export interface Email {
+  email: string;
+}
+
 export class Auth {
   constructor(
     public isAuth: boolean

--- a/ui/src/app/service/auth.service.ts
+++ b/ui/src/app/service/auth.service.ts
@@ -2,7 +2,7 @@ import { Injectable }              from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import { User, Signup, Auth } from '../interface/user';
+import { User, Signup, Email } from '../interface/user';
 
 @Injectable({
   providedIn: 'root'
@@ -86,11 +86,23 @@ export class AuthService {
    * HTTP GET メソッドを実行する
    * (認証,認可用のコード)
    *
-   * @return    An `Observable` of the response body as a `{ isAuth: boolean }`.
+   * @return    An `Observable` of the respon:se body as a `{ isAuth: boolean }`.
    * @param url 認証、認可用のエンドポイント
    * @memberof  HttpClientService
    */
   isAuthenticate(): Observable<{ isAuth: boolean }> {
-    return this.http.get< {isAuth: boolean} >(`${this.authUrl}/isAuthenticate`, this.httpOptions)
+    return this.http.get< {isAuth: boolean} >(`${this.authUrl}/isAuthenticate`, this.httpOptions);
+  }
+
+  /**
+   * HTTP POST メソッドを実行する
+   * (Emailが登録済みかどうかを確認するコード)
+   *
+   * @return    An `Observable` of the response body as a `{ isRegistered: boolean }`.
+   * @param url Emailが登録済みかどうかを確認するエンドポイント
+   * @memberof  HttpClientService
+   */
+  isEmailRegistered(payload: {email: string}): Observable<{ isRegistered: boolean }> {
+    return this.http.post<{ isRegistered: boolean }>(`${this.authUrl}/isEmailRegistered`, payload, this.httpOptions);
   }
 }

--- a/ui/src/app/service/validation.service.ts
+++ b/ui/src/app/service/validation.service.ts
@@ -1,24 +1,46 @@
 import { Injectable }              from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
+import { AsyncValidatorFn, AbstractControl, ValidationErrors } from '@angular/forms';
+
+import { Observable }  from 'rxjs';
+import { map }         from 'rxjs/operators';
+
+import { AuthService } from './auth.service'
 
 @Injectable({
   providedIn: 'root'
 })
 export class ValidationService {
 
-  constructor() { }
+  constructor(
+    private authService: AuthService
+  ) {}
 
   // ---- [ variable ] -------------
   /**
    *
    * メールアドレスのバリデーション
-   * @export Email Login Signup Component
-   */
-  email = new FormControl('', [
-    Validators.required,
-    Validators.email
-  ]);
-  
+   * @export Email Signup Component
+   *
+   * メールアドレスを共通化した場合の処理分けができなかったため、
+   * 一旦保留
+   *
+  signupEmail = new FormControl('',
+    [
+      Validators.required,
+      Validators.email,
+    ],
+    this.emailRegisteredSome()
+  );
+  loginEmail = new FormControl('',
+    [
+      Validators.required,
+      Validators.email,
+    ],
+    this.emailRegisteredNone()
+  );
+  */
+
   /**
    *
    * パスワードのバリデーション
@@ -30,11 +52,44 @@ export class ValidationService {
   ]);
 
   // ---- [ method ] ----------------
-  validateEmail(): FormControl {
-    return this.email
+  /*
+   * メールアドレスを共通化した場合の処理分けができなかったため、
+   * 一旦保留
+   *
+  validateSignup(): FormControl {
+    return this.signupEmail
   }
-  
+  */
   validatePassword(): FormControl {
     return this.password
+  }
+
+  /**
+   *
+   * メールアドレスが登録済みかどうかののバリデーション
+   * @export email Signup Component
+   */
+  emailRegisteredSome(): AsyncValidatorFn {
+    return (control: AbstractControl): Observable<ValidationErrors | null> => {
+      return this.authService.isEmailRegistered({email: control.value}).pipe(
+        map(email => {
+          return email.isRegistered ? { registered: true } : null;
+        })
+      )
+    }
+  }
+  /**
+   *
+   * メールアドレスが登録済みかどうかののバリデーション
+   * @export email Login Component
+   */
+  emailRegisteredNone(): AsyncValidatorFn {
+    return (control: AbstractControl): Observable<ValidationErrors | null> => {
+      return this.authService.isEmailRegistered({email: control.value}).pipe(
+        map(email => {
+          return email.isRegistered ? null : { none: true };
+        })
+      )
+    }
   }
 }


### PR DESCRIPTION
# PullRequest
## Issues
[[SPA-017]](https://github.com/takapi327/scala-play-app/issues/41)
## Sumamry
メールアドレスの重複をなくすため重複処理のバリデーションを実装
## Note
当初メールアドレスのフォームをログイン、サインアップで共通化していたが上記実装の処理わけが上手く機能しなかったため共通化を解除して実装している。
リファクタリング対象